### PR TITLE
Possible bug fix

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -229,7 +229,7 @@ module INotify
       rescue SystemCallError => er
         # EINVAL means that there's more data to be read
         # than will fit in the buffer size
-        raise er unless er.errno == EINVAL || tries == 5
+        raise er unless er.errno == Errno::EINVAL::Errno || tries == 5
         size *= 2
         tries += 1
         retry


### PR DESCRIPTION
I keep getting the following stack trace when using inotify:
http://gist.github.com/577621

Looking at notifier.rb:232, I see:
raise er unless er.errno == EINVAL || tries == 5

I changed this to this:
raise er unless er.errno == Errno::EINVAL::Errno || tries == 5

Seems to work?
