### PR TITLE
User Dir.glob instead of Dir.entries

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -181,7 +181,8 @@ module INotify
     def watch(path, *flags, &callback)
       return Watcher.new(self, path, *flags, &callback) unless flags.include?(:recursive)
 
-      Dir.glob(File.join(path, '{*,.*}')).each do |d|
+      Dir.glob(File.join(path, '*'), File::FNM_DOTMATCH).each do |d|
+        next if d =~ /\/\.\.?$/ # Current or parent directory
         watch(d, *flags, &callback) if !RECURSIVE_BLACKLIST.include?(d) && File.directory?(d)
       end
 


### PR DESCRIPTION
Use Dir.glob instead of Dir.entries to work around bug when files are deleted shortly after method invocation.

Read more: https://github.com/guard/guard/issues/31
