### PR TITLE
Autotest + autotest-inotify breaks

### DIFF
--- a/lib/rb-inotify/watcher.rb
+++ b/lib/rb-inotify/watcher.rb
@@ -58,7 +58,7 @@ module INotify
       @callback = callback || proc {}
       @path = path
       @flags = flags.freeze
-      @id = Native.inotify_add_watch(@notifier.fd, path,
+      @id = Native.inotify_add_watch(@notifier.fd, path.dup,
         Native::Flags.to_mask(flags))
 
       unless @id < 0


### PR DESCRIPTION
With the latest gems autotest, autotest-inotify, rb-inotify an exception is raised:

```
autotest.rb:842:in `block in <class:Autotest>': undefined method `backtrace' for [#<RuntimeError: can't modify frozen string>]:Array (NoMethodError)
```

It boils down to:

```
@id = Native.inotify_add_watch(@notifier.fd, path, Native::Flags.to_mask(flags))
```

the path variable is frozen and FFI doesn't handle const strings hence the exception
