### PR TITLE
Fix for crash of Guard when some file is created and deleted very fast at the top directory of watching.

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -190,7 +190,10 @@ module INotify
       return watch(path, *((flags - [:recursive]) | rec_flags)) do |event|
         callback.call(event) if flags.include?(:all_events) || !(flags & event.flags).empty?
         next if (rec_flags & event.flags).empty? || !event.flags.include?(:isdir)
-        watch(event.absolute_name, *flags, &callback) if File.exists?(event.absolute_name)
+        begin
+          watch(event.absolute_name, *flags, &callback)
+        rescue Errno::ENOENT
+        end
       end
     end
 


### PR DESCRIPTION
rb-inotify crashes when is used by Guard and some file is created and then
is deleted very fast at the top of watching directory.

My changes is related to the same problem as issue #10. The fix that was applied to close that issue helps a lot, but I still experience problems when some program creates and then deletes lock file in the top of watched dir.

I am not 100% sure about the change I expose, but it works for me. Could you please review it and says if that make sense? If so, consider to apply it on master.

Thank you in advance!
