### PR TITLE
Use FFI::Library::LIBC in favor of magic "c" constant when calling ffi_lib.

### DIFF
--- a/lib/rb-inotify/native.rb
+++ b/lib/rb-inotify/native.rb
@@ -8,7 +8,7 @@ module INotify
   # @private
   module Native
     extend FFI::Library
-    ffi_lib "c"
+    ffi_lib FFI::Library::LIBC
 
     # The C struct describing an inotify event.
     #


### PR DESCRIPTION
- The current code uses a magic literal constant `"c"`.
  This breaks under my archlinux. I need `"libc.so.6"`.
  The `FFI::Library::LIBC` constant is especially designed
  to take care on these differences as it delegates to
  `FFI::Platform::LIBC` that is in my case the `"libc.so.6"`.

I suspect this change will work for other platforms very well.
