### PR TITLE
Update lib/rb-inotify/notifier.rb

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -189,7 +189,8 @@ module INotify
     def watch(path, *flags, &callback)
       return Watcher.new(self, path, *flags, &callback) unless flags.include?(:recursive)
 
-      Dir.glob(File.join(path, '*'), File::FNM_DOTMATCH).each do |d|
+      Dir.new(path).each do |base|
+        d = File.join(path, base)
         binary_d = d.respond_to?(:force_encoding) ? d.dup.force_encoding('BINARY') : d
         next if binary_d =~ /\/\.\.?$/ # Current or parent directory
         watch(d, *flags, &callback) if !RECURSIVE_BLACKLIST.include?(d) && File.directory?(d)


### PR DESCRIPTION
I ran into a problem caused by an oddly named directory which resulted in the inotify backend for guard reliably crashing out on a rails project.

The follow snippet demonstrates the issue:

``` ruby
require 'rb-inotify'
require 'fileutils'

FileUtils.mkdir_p("test-1/**")

listener = INotify::Notifier.new
listener.watch("test-1", :all_events, :recursive) do |event|
  p event
end
```

When it encounters a directory named '**', the current code (using Dir.glob) enters an infinite, recursive loop until it throws a SystemStackError, because the directory name is a self-matching glob pattern.

As the code in #watch is only using Dir.glob as a convenient way to get a path, rather than just a list of leafnames, I figure the best solution is to switch to Dir.new?
