### PR TITLE
Fix fd leak in INotify::Notifier

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -189,12 +189,16 @@ module INotify
     def watch(path, *flags, &callback)
       return Watcher.new(self, path, *flags, &callback) unless flags.include?(:recursive)
 
-      Dir.new(path).each do |base|
+      dir = Dir.new(path)
+
+      dir.each do |base|
         d = File.join(path, base)
         binary_d = d.respond_to?(:force_encoding) ? d.dup.force_encoding('BINARY') : d
         next if binary_d =~ /\/\.\.?$/ # Current or parent directory
         watch(d, *flags, &callback) if !RECURSIVE_BLACKLIST.include?(d) && File.directory?(d)
       end
+
+      dir.close
 
       rec_flags = [:create, :moved_to]
       return watch(path, *((flags - [:recursive]) | rec_flags)) do |event|


### PR DESCRIPTION
Currenty, there's a leak of file descriptors in the `INotify::Notifier.watch()` method class when calling it with the `:recursive` flag. 

If a directory is opened via `Dir.new()` it should always be closed via `Dir.close()` afterwards, otherwise one file descriptor for each watched directory is leaked.
