### PR TITLE
Fix crash when creating new files with utf8 specific characters on utf8 filesystems

### DIFF
--- a/lib/rb-inotify/event.rb
+++ b/lib/rb-inotify/event.rb
@@ -113,7 +113,7 @@ module INotify
       @native = Native::Event.new(ptr)
       @related = []
       @cookie = @native[:cookie]
-      @name = data[@native.size, @native[:len]].gsub(/\0+$/, '').force_encoding('filesystem')
+      @name = fix_encoding(data[@native.size, @native[:len]].gsub(/\0+$/, ''))
       @notifier = notifier
       @watcher_id = @native[:wd]
 
@@ -134,6 +134,13 @@ module INotify
     # @return [Fixnum]
     def size
       @native.size + @native[:len]
+    end
+
+    private
+
+    def fix_encoding(name)
+      name.force_encoding('filesystem') if name.respond_to?(:force_encoding)
+      name
     end
   end
 end


### PR DESCRIPTION
On my utf8 filesystem, I got the following error while running guard cucumber 

```
/home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:193:in `join': incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:193:in `block in watch'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:192:in `each'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:192:in `watch'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:204:in `block in watch'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/watcher.rb:41:in `[]'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/watcher.rb:41:in `callback!'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/event.rb:128:in `callback!'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:234:in `block in process'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:234:in `each'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:234:in `process'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/rb-inotify-0.9.0/lib/rb-inotify/notifier.rb:217:in `run'
    from /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/vendor/bundle/gems/listen-1.2.2/lib/listen/adapters/linux.rb:76:in `block in start_worker'
```

Details on the failing join :

```
Path.join(path, base)
path (ASCII-8BIT): /home/philou/Dropbox/mes-courses.fr/Code/WIP/mes-courses-dev/tmp/dummy-store/www.dummy-store.com/Marché
base (UTF-8): Légumes
```

When the "Marché" directory was created, the native event's bytes are stored inside an ASCII-8BIT chain (standard encoding for readpartial result), but when cleanedup in Event.initialize, the encoding is kept whatever the real filesystem encoding. This only worked as long as the file name contains only ascii-8bit compatible characters.

There is no force_encoding method on ruby 1.8.x, I know my patch is not ruby 1.8 compatible. I don't know if this is an issue.
