### PR TITLE
Prevent INotify::Watchers from being leaked

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -242,7 +242,10 @@ module INotify
     #
     # @raise [SystemCallError] if closing the underlying file descriptor fails.
     def close
-      return if Native.close(@fd) == 0
+      if Native.close(@fd) == 0
+        @watchers.clear
+        return
+      end
 
       raise SystemCallError.new("Failed to properly close inotify socket" +
        case FFI.errno

--- a/lib/rb-inotify/watcher.rb
+++ b/lib/rb-inotify/watcher.rb
@@ -45,8 +45,13 @@ module INotify
     #
     # @raise [SystemCallError] if the watch fails to be disabled for some reason
     def close
-      return if Native.inotify_rm_watch(@notifier.fd, @id) == 0
-      raise SystemCallError.new("Failed to stop watching #{path.inspect}", FFI.errno)
+      if Native.inotify_rm_watch(@notifier.fd, @id) == 0
+        @notifier.watchers.delete(@id)
+        return
+      end
+
+      raise SystemCallError.new("Failed to stop watching #{path.inspect}",
+                                FFI.errno)
     end
 
     # Creates a new {Watcher}.


### PR DESCRIPTION
Specifically:
1. When a watcher is #close'd , it should delete itself from the INotify::Notifier watchers hash
2. When an INotify::Notifier is #close'd, it should clear it watchers hash
