### PR TITLE
Add licenses to gemspec

### DIFF
--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.authors = ["Nathan Weizenbaum"]
   s.date = "2014-04-25"
   s.description = "A Ruby wrapper for Linux's inotify, using FFI"
+  s.licenses = ['MIT']
   s.email = "nex342@gmail.com"
   s.extra_rdoc_files = [
     "README.md"


### PR DESCRIPTION
This should be enough to have it show up on rubygems.org
