### PR TITLE
Use a specific exception class for queue overflows

### DIFF
--- a/lib/rb-inotify.rb
+++ b/lib/rb-inotify.rb
@@ -3,6 +3,7 @@ require 'rb-inotify/native/flags'
 require 'rb-inotify/notifier'
 require 'rb-inotify/watcher'
 require 'rb-inotify/event'
+require 'rb-inotify/errors'
 
 # The root module of the library, which is laid out as so:
 #

--- a/lib/rb-inotify/errors.rb
+++ b/lib/rb-inotify/errors.rb
@@ -1,0 +1,3 @@
+module INotify
+  class QueueOverflowError < RuntimeError; end
+end

--- a/lib/rb-inotify/event.rb
+++ b/lib/rb-inotify/event.rb
@@ -117,7 +117,7 @@ module INotify
       @notifier = notifier
       @watcher_id = @native[:wd]
 
-      raise Exception.new("inotify event queue has overflowed.") if @native[:mask] & Native::Flags::IN_Q_OVERFLOW != 0
+      raise QueueOverflowError.new("inotify event queue has overflowed.") if @native[:mask] & Native::Flags::IN_Q_OVERFLOW != 0
     end
 
     # Calls the callback of the watcher that fired this event,


### PR DESCRIPTION
6ea8bf75c974a6caf1868518e0d5b19182e1faa9 caused INotify::Event to raise
an Exception if the event queue overflows. Since Exception is the
parent of all exceptions in Ruby, including language errors, this makes
that failure case difficult to handle in applications, since
"rescue Exception" will catch _any_ exception that is raised.

Here, we create a new exception class, INotify::QueueOverflowError, and
raise an instance of that if the queue overflows. Handling this error
in a client application is now as simple as:

  begin
    inotify.process
  rescue INotify::QueueOverflowError
    (re-read all watched files, or whatever is appropriate)
  end
