### PR TITLE
Fix the logic used for retrying reads after EINVAL

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -269,7 +269,7 @@ module INotify
       rescue SystemCallError => er
         # EINVAL means that there's more data to be read
         # than will fit in the buffer size
-        raise er unless er.errno == Errno::EINVAL::Errno || tries == 5
+        raise er unless er.errno == Errno::EINVAL::Errno && tries < 5
         size *= 2
         tries += 1
         retry


### PR DESCRIPTION
The previous way of testing for EINVAL here would have retried
indefinitely for as long as EINVAL was returned, instead of giving up
after five tries (as was obviously the intent). This commit makes it
retry only if tries is less than 5, rather than if tries is equal to 5.
