### PR TITLE
Clear watchers even if closing FD fails

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -242,8 +242,8 @@ module INotify
     #
     # @raise [SystemCallError] if closing the underlying file descriptor fails.
     def close
+      @watchers.clear
       if Native.close(@fd) == 0
-        @watchers.clear
         return
       end
 


### PR DESCRIPTION
If the underlying file descriptor is invalid or closed, then a call to `Notifier.close` will leave `@watchers` untouched.
I think we should clear them nevertheless, as otherwise there's no way to clear them.
wdyt?
