### PR TITLE
[FIX] Guard crush on exit fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.yardoc
 /doc
 /pkg
+*.gem

--- a/lib/rb-inotify.rb
+++ b/lib/rb-inotify.rb
@@ -3,7 +3,6 @@ require 'rb-inotify/native/flags'
 require 'rb-inotify/notifier'
 require 'rb-inotify/watcher'
 require 'rb-inotify/event'
-require 'rb-inotify/errors'
 
 # The root module of the library, which is laid out as so:
 #

--- a/lib/rb-inotify/errors.rb
+++ b/lib/rb-inotify/errors.rb
@@ -1,3 +1,0 @@
-module INotify
-  class QueueOverflowError < RuntimeError; end
-end

--- a/lib/rb-inotify/event.rb
+++ b/lib/rb-inotify/event.rb
@@ -117,7 +117,7 @@ module INotify
       @notifier = notifier
       @watcher_id = @native[:wd]
 
-      raise QueueOverflowError.new("inotify event queue has overflowed.") if @native[:mask] & Native::Flags::IN_Q_OVERFLOW != 0
+      raise Exception.new("inotify event queue has overflowed.") if @native[:mask] & Native::Flags::IN_Q_OVERFLOW != 0
     end
 
     # Calls the callback of the watcher that fired this event,

--- a/lib/rb-inotify/event.rb
+++ b/lib/rb-inotify/event.rb
@@ -125,7 +125,7 @@ module INotify
     #
     # @private
     def callback!
-      watcher.callback!(self)
+      watcher.callback!(self) if watcher
     end
 
     # Returns the size of this event object in bytes,

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -269,7 +269,7 @@ module INotify
       rescue SystemCallError => er
         # EINVAL means that there's more data to be read
         # than will fit in the buffer size
-        raise er unless er.errno == Errno::EINVAL::Errno && tries < 5
+        raise er unless er.errno == Errno::EINVAL::Errno || tries == 5
         size *= 2
         tries += 1
         retry

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -269,6 +269,7 @@ module INotify
       rescue SystemCallError => er
         # EINVAL means that there's more data to be read
         # than will fit in the buffer size
+        return [] if er.errno == Errno::EBADF::Errno && self.class.supports_ruby_io?
         raise er unless er.errno == Errno::EINVAL::Errno || tries == 5
         size *= 2
         tries += 1


### PR DESCRIPTION
First commit fix changes between sourse from github and sourse from rubygems.
It was very tricky

The second one fix guard crush on exit.
My guard addition list is:

```
  gem 'guard'
  gem 'guard-migrate'
  gem 'guard-bundler', require: false
  gem 'guard-livereload', '~> 2.4', require: false
  gem 'guard-rspec', require: false
  gem 'guard-rails', require: false
```

and on exit i've got (it's not the last version of error, but enougth to get into the idea)

```
[1] guard(main)> exit                                                                                    

Exiting
E, [2016-01-21T22:17:37.085389 #17203] ERROR -- : run() in thread failed: undefined method `callback!' for nil:NilClass:\n /home/kvokka/.rvm/gems/ruby-2.3.0/gems/rb-inotify-0.9.5/lib/rb-inotify/event.rb:128:in `callback!'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/rb-inotify-0.9.5/lib/rb-inotify/notifier.rb:238:in `block in process'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/rb-inotify-0.9.5/lib/rb-inotify/notifier.rb:238:in `each'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/rb-inotify-0.9.5/lib/rb-inotify/notifier.rb:238:in `process'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/rb-inotify-0.9.5/lib/rb-inotify/notifier.rb:221:in `run'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/adapter/linux.rb:38:in `_run'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/adapter/base.rb:78:in `block in start'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/internals/thread_pool.rb:6:in `block in add'\n\ncalled from:\n /home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/backend.rb:26:in `start'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/listener.rb:67:in `block in <class:Listener>'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/fsm.rb:120:in `instance_eval'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/fsm.rb:120:in `call'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/fsm.rb:91:in `transition_with_callbacks!'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/fsm.rb:57:in `transition'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/listen-3.0.5/lib/listen/listener.rb:90:in `start'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/guard-2.13.0/lib/guard/commander.rb:35:in `start'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/guard-2.13.0/lib/guard/cli/environments/valid.rb:16:in `start_guard'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/guard-2.13.0/lib/guard/cli.rb:122:in `start'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/guard-2.13.0/lib/guard/aruba_adapter.rb:32:in `execute'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/guard-2.13.0/lib/guard/aruba_adapter.rb:19:in `execute!'
/home/kvokka/.rvm/gems/ruby-2.3.0/gems/guard-2.13.0/bin/_guard-core:11:in `<main>'
```

This fix swith off error raising
