### PR TITLE
Delete ignored watchers and documentation fix

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -235,7 +235,10 @@ module INotify
     #
     # @see #run
     def process
-      read_events.each {|event| event.callback!}
+      read_events.each do |event|
+        event.callback!
+        event.flags.include?(:ignored) && event.notifier.watchers.delete(event.watcher_id)
+      end
     end
 
     # Close the notifier.
@@ -282,7 +285,6 @@ module INotify
       events = []
       cookies = {}
       while event = Event.consume(data, self)
-        event.flags.include?(:ignored) && event.notifier.watchers.delete(event.watcher_id)
         events << event
         next if event.cookie == 0
         cookies[event.cookie] ||= []

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -116,6 +116,12 @@ module INotify
     # `:open`
     # : A file is opened.
     #
+    # `:delete_self`
+    # : The watched file or directory itself is deleted.
+    #
+    # `:move_self`
+    # : The watched file or directory itself is moved.
+    #
     # ### Directory-Specific Flags
     #
     # These flags only apply when a directory is being watched.
@@ -131,12 +137,6 @@ module INotify
     #
     # `:delete`
     # : A file is deleted in the watched directory.
-    #
-    # `:delete_self`
-    # : The watched file or directory itself is deleted.
-    #
-    # `:move_self`
-    # : The watched file or directory itself is moved.
     #
     # ### Helper Flags
     #

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -116,12 +116,6 @@ module INotify
     # `:open`
     # : A file is opened.
     #
-    # `:delete_self`
-    # : The watched file or directory itself is deleted.
-    #
-    # `:move_self`
-    # : The watched file or directory itself is moved.
-    #
     # ### Directory-Specific Flags
     #
     # These flags only apply when a directory is being watched.
@@ -137,6 +131,12 @@ module INotify
     #
     # `:delete`
     # : A file is deleted in the watched directory.
+    #
+    # `:delete_self`
+    # : The watched file or directory itself is deleted.
+    #
+    # `:move_self`
+    # : The watched file or directory itself is moved.
     #
     # ### Helper Flags
     #
@@ -282,6 +282,7 @@ module INotify
       events = []
       cookies = {}
       while event = Event.consume(data, self)
+        event.flags.include?(:ignored) && event.notifier.watchers.delete(event.watcher_id)
         events << event
         next if event.cookie == 0
         cookies[event.cookie] ||= []


### PR DESCRIPTION
First: when a watcher receives the :ignored flag it remains in the notifier.watchers list and can't be closed with watcher.close, because it has already been removed from the inotify native library but it remains inserted into the notifier.watchers hash.
This would cause the hash to grow indefinitely and it's not desirable.
I added a line of code that removes the hash entry when the :ignored flags is received.

Second: event flags :move_self and :delete_self can happen on files also, not only on directories. Fixed documentation.

Please review the changes and merge if you think it's valid.

Anyway thanks so far for your useful job.
