### PR TITLE
Add JRuby and Rubinius cases on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,12 @@ rvm:
   - 2.4
   - jruby-head
   - ruby-head
+  - jruby-9.1.8.0
+  - jruby-head
+  - rbx-3
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-3
+  fast_finish: true


### PR DESCRIPTION
I just knew that `rb-inotify` is used with JRuby seeing issue page's user report.
This PR must be useful to share issues of JRuby and Rubinius easily.

I added Rubinius (`rbx-3`) as `allow_failures` as it is sometimes unstable.
This set of CRuby, JRuby and Rubinius in `.travis.yml` is typically used for some RubyGem packages.
