### PR TITLE
Fix for breaking change for Ruby and runtime dependency version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 dist: trusty
 cache: bundler
 rvm:
+  - 1.8
+  - 1.9
   - 2.0
   - 2.1
   - 2.2
@@ -19,3 +21,10 @@ matrix:
     - rvm: jruby-head
     - rvm: rbx-3
   fast_finish: true
+script:
+  # Unit test
+  - bundle exec rake
+  # Install test
+  - gem build rb-inotify.gemspec
+  - gem install rb-inotify-*.gem
+  - sh -c "gem list | grep rb-inotify"

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,18 @@ gemspec
 
 group :development do
 	gem 'pry'
-	gem 'pry-coolline'
-	
+  # coolline is a runtime dependency of pry-coolline.
+  # unicode_utils is a runtime dependency of coolline.
+  # unicode_utils requires Ruby '> 1.9' from 1st version.
+  gem 'pry-coolline' if RUBY_VERSION >= '1.9.1'
 	gem 'tty-prompt'
 end
 
 group :test do
 	gem 'simplecov'
-	gem 'coveralls', require: false
+	gem 'coveralls', :require => false
+  # tins is a runtime dependency of coveralls.
+  gem 'tins', '~> 1.6.0' if RUBY_VERSION < '2.0'
+  # term-ansicolor is a runtime dependency of coveralls.
+  gem 'term-ansicolor', '~> 1.3.2' if RUBY_VERSION < '2.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,10 @@
 require "bundler/gem_tasks"
-require 'rake/testtask'
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new do |t|
-  t.libs << 'test'
-end
+RSpec::Core::RakeTask.new(:spec)
 
 desc "Run tests"
-task :default => :test
+task :default => :spec
 
 task :console do
   require 'rb-inotify'

--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
-require_relative 'lib/rb-inotify/version'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+require 'rb-inotify/version'
 
 Gem::Specification.new do |spec|
   spec.name     = 'rb-inotify'
@@ -16,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
-  spec.required_ruby_version = '>= 2.0.0'
-  
-  spec.add_dependency "ffi", "~> 1.0"
-  
+
+  spec.required_ruby_version = '>= 0'
+
+  spec.add_dependency 'ffi', '>= 0.5.0', '< 2'
+
   spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This fixes https://github.com/guard/rb-inotify/issues/68
I guess that we can release 0.9.10.
Because changing Ruby and run time dependency packages condition with maintenance version (Z of X.Y.Z) is not user friendly.

If you want to change those, the timing of major or minor version bump looks better.

## Detail

* Fix for breaking change for dependency condition from 0.9.8 to 0.9.9.
  Keep Ruby and runtime dependency (ffi) to be same with rb-inotify 0.9.8.
* Fix skipped tests logic in Rakefile.
* Add Ruby 1.8, 1.9 test case on Travis.
* Add release test on Travis.

As you know, current `bundle exec rake` does not work. You can see the test result is not displayed.
So, I fixed it.

```
$ bundle exec rake
/usr/local/ruby-2.4.1/bin/ruby -I/home/jaruga/git/rb-inotify/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.4.4/lib:/home/jaruga/git/rb-inotify/vendor/bundle/ruby/2.4.0/gems/rspec-support-3.4.1/lib /home/jaruga/git/rb-inotify/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.4.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
..

Finished in 0.00142 seconds (files took 0.07249 seconds to load)
2 examples, 0 failures
```
