### PR TITLE
Fix to suppress warning when "gem build rb-inotify.gemspec".

### DIFF
--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 0.5.0', '< 2'
 
-  spec.add_development_dependency "rspec", "~> 3.4.0"
+  spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  # rake 11.x requires Ruby >= 1.9.3
+  spec.add_development_dependency "rake", ">= 10.5.0", "< 13"
 end


### PR DESCRIPTION
To suppress below warning.

```
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

$ gem build rb-inotify.gemspec
WARNING:  pessimistic dependency on rspec (~> 3.4.0, development) may be overly strict
  if rspec is semantically versioned, use:
    add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rb-inotify
  Version: 0.9.10
  File: rb-inotify-0.9.10.gem
```
