### PR TITLE
Use Trusty OS for only rbx environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 sudo: false
-dist: trusty
 cache: bundler
 rvm:
   - 2.0
@@ -12,8 +11,10 @@ rvm:
   - ruby-head
   - jruby-9.1.8.0
   - jruby-head
-  - rbx-3
 matrix:
+  include:
+    - rvm: rbx-3
+      dist: trusty
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
This PR is to master branch.

https://travis-ci.org/guard/rb-inotify/jobs/243945630
> This job ran on our container-based trusty beta. Please read our blog post about the public beta. 

Right now Travis on Trusty OS is running as beta version. (From when?)
And it is something wrong.

I had to wait for 5 hours until starting the Travis test.

We know that only rbx environment needs Trusty OS.
This PR is not to use Trusty OS as much as possible.

I want to check total running time by this PR.
