### PR TITLE
Drop all unsupported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 dist: trusty
 cache: bundler
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
   - 2.3
   - 2.4

--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
   
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.2'
   
   spec.add_dependency "ffi", "~> 1.0"
   


### PR DESCRIPTION
If we're dropping versions (https://github.com/guard/rb-inotify/issues/68#issuecomment-309246625), we might as well drop everything that's officially unsupported: https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/