### PR TITLE
Run guard and listen specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 .tags*
 .rspec_status
 /guard/
+/listen/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 .tags*
 .rspec_status
+/guard/

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,9 @@ script:
   - gem install rb-inotify-*.gem
   - "gem list | grep rb-inotify"
   - ruby -e 'require "rb-inotify"'
+  # Integration test
+  - git clone https://github.com/matthewd/guard -b inotify-test-target --depth 1
+  - cd guard
+  - export BUNDLE_GEMFILE=$PWD/Gemfile
+  - bundle install --without development
+  - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,17 @@ script:
   - gem install rb-inotify-*.gem
   - "gem list | grep rb-inotify"
   - ruby -e 'require "rb-inotify"'
-  # Integration test
+  # Integration test: guard
   - git clone https://github.com/matthewd/guard -b inotify-test-target --depth 1
   - cd guard
   - export BUNDLE_GEMFILE=$PWD/Gemfile
+  - bundle install --without development
+  - bundle exec rake
+  - cd ..
+  # Integration test: listen
+  - git clone https://github.com/matthewd/listen -b inotify-test-target --depth 1
+  - cd listen
+  - export BUNDLE_GEMFILE=$PWD/Gemfile
+  - gem install ruby_dep
   - bundle install --without development
   - bundle exec rake


### PR DESCRIPTION
For now I'm pointing at a branch in my fork for each, which is based on each gem's respective most recent tagged release. AFAICS, there's no particular reason we'd need to follow their future releases, unless they add notable new specs.

Given some useful level of local specs, it shouldn't be necessary to run these full suites across all ruby versions, but this is a start for now.