### PR TITLE
Ensure the IO always gets closed, exactly once (redux)

### DIFF
--- a/lib/rb-inotify/native.rb
+++ b/lib/rb-inotify/native.rb
@@ -29,8 +29,5 @@ module INotify
     attach_function :inotify_add_watch, [:int, :string, :uint32], :int
     attach_function :inotify_rm_watch, [:int, :uint32], :int
     attach_function :fpathconf, [:int, :int], :long
-
-    attach_function :read, [:int, :pointer, :size_t], :ssize_t
-    attach_function :close, [:int], :int
   end
 end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -92,7 +92,6 @@ describe INotify::Notifier do
         expect(events.map(&:name)).to match_array(%w(one.txt two.txt))
 
         @notifier.stop
-        sleep 0.5
 
         dir.join("three.txt").write("hello world")
         barriers.shift.wait(1)
@@ -100,14 +99,7 @@ describe INotify::Notifier do
         dir.join("four.txt").write("hello world")
         run_thread.join
 
-        expect(events.map(&:name)).not_to include("four.txt")
-
-        if RUBY_PLATFORM != "java"
-          # TODO: MRI doesn't actually stop until after it receives the
-          # next event *after* #stop is called, so 'three' is here. Java
-          # is less consistent.
-          expect(events.map(&:name)).to match_array(%w(one.txt two.txt three.txt))
-        end
+        expect(events.map(&:name)).to match_array(%w(one.txt two.txt))
       end
     end
 


### PR DESCRIPTION
Take two on #49 

Incidentally fixes #47 -- it's necessary for our tests to behave consistently. If a higher level library is doing its own `select` management, this should have no impact... but otherwise, our `readpartial` and higher level `process` and `run` methods are all blocking, so ISTM it behooves us to ensure `stop` actually stops.

This take is less complex than #49: it doesn't need the manual Handle, because per https://github.com/guard/rb-inotify/pull/49#issuecomment-309284081, we're now always relying on native IO (#78).