### PR TITLE
Exclude ffi 1.9.22 and ffi 1.9.23

### DIFF
--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   
   spec.required_ruby_version = '>= 2.2'
   
-  spec.add_dependency "ffi", "~> 1.0"
+  spec.add_dependency "ffi", "~> 1.0", '!= 1.9.22', '!= 1.9.23'
   
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Excluding ffi 1.9.22 and ffi 1.9.23 due to Segfault on macOS and SIGABRT on Centos/RHEL 6+7. Fixes #86 