### PR TITLE
Exclude ffi versions 1.9.22 and 1.9.23

### DIFF
--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 0'
 
-  spec.add_dependency 'ffi', '>= 0.5.0', '< 2'
+  spec.add_dependency 'ffi', '>= 0.5.0', '< 2', '!= 1.9.22', '!= 1.9.23' 
 
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Excluding ffi 1.9.22 and ffi 1.9.23 due to Segfault on macOS and SIGABRT on Centos/RHEL 6+7.