### PR TITLE
Fixes #91.  Make IO resources not autoclose.

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -52,15 +52,17 @@ module INotify
       @running = Mutex.new
       @pipe = IO.pipe
       # JRuby shutdown sometimes runs IO finalizers before all threads finish.
-      @pipe[0].autoclose = false
-      @pipe[1].autoclose = false
+      if RUBY_ENGINE == 'jruby'
+        @pipe[0].autoclose = false
+        @pipe[1].autoclose = false
+      end
 
       @watchers = {}
 
       fd = Native.inotify_init
       unless fd < 0
         @handle = IO.new(fd)
-        @handle.autoclose = false
+        @handle.autoclose = false if RUBY_ENGINE == 'jruby'
         return
       end
 

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -51,12 +51,16 @@ module INotify
     def initialize
       @running = Mutex.new
       @pipe = IO.pipe
+      # JRuby shutdown sometimes runs IO finalizers before all threads finish.
+      @pipe[0].autoclose = false
+      @pipe[1].autoclose = false
 
       @watchers = {}
 
       fd = Native.inotify_init
       unless fd < 0
         @handle = IO.new(fd)
+        @handle.autoclose = false
         return
       end
 


### PR DESCRIPTION
A later JRuby release may allow these autoclose=false statements to be
removed (although @handle may desire to keep it's due to to_io handing
that IO out to external consumers).  The basic problem is currently during
shutdown JRuby Threads may not have finished executing before finalizers
start firing.  JRuby is looking at sending a more explicit termination
request similar to MRI to threads on shutdown, which may obviate the need
for this.  That change is too risky in the near term so we are requesting
this PR for the time being.