### PR TITLE
allow stopping a notifier from within an event callback

### DIFF
--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -101,6 +101,16 @@ describe INotify::Notifier do
 
         expect(events.map(&:name)).to match_array(%w(one.txt two.txt))
       end
+
+      it "can be stopped from within a callback" do
+        barriers = Array.new(3) { Concurrent::Event.new }
+        barrier_queue = barriers.dup
+        events = recording(dir, :create) { @notifier.stop }
+
+        run_thread = Thread.new { @notifier.run }
+        dir.join("one.txt").write("hello world")
+        run_thread.join
+      end
     end
 
     describe :fd do


### PR DESCRIPTION
This was allowed pre-0.10.0 but got broken by the synchronization
of #stop with #run quitting.