### PR TITLE
Prevent race condition in Notifier#run / #stop

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -50,6 +50,7 @@ module INotify
     # @raise [SystemCallError] if inotify failed to initialize for some reason
     def initialize
       @running = Mutex.new
+      @stop = false
       @pipe = IO.pipe
       # JRuby shutdown sometimes runs IO finalizers before all threads finish.
       if RUBY_ENGINE == 'jruby'
@@ -231,12 +232,12 @@ module INotify
     def run
       @running.synchronize do
         Thread.current[:INOTIFY_RUN_THREAD] = true
-        @stop = false
 
         process until @stop
       end
     ensure
       Thread.current[:INOTIFY_RUN_THREAD] = false
+      @stop = false
     end
 
     # Stop watching for filesystem events.

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -111,6 +111,20 @@ describe INotify::Notifier do
         dir.join("one.txt").write("hello world")
         run_thread.join
       end
+
+      it "can be stopped before it starts processing" do
+        barrier = Concurrent::Event.new
+
+        run_thread = Thread.new do
+          barrier.wait
+          @notifier.run
+        end
+
+        @notifier.stop
+        barrier.set
+
+        run_thread.join(1) or raise "timeout"
+      end
     end
 
     describe :fd do


### PR DESCRIPTION
There is a potential race condition when a notifier is run in a new thread and then immediately stopped in the original thread.  If `Notifier#stop` sets [`@stop = true`](https://github.com/guard/rb-inotify/blob/3cee3331033a9d2cb642076de8aefac3bf0f4e3b/lib/rb-inotify/notifier.rb#L246) before `Notifier#run` sets [`@stop = false`](https://github.com/guard/rb-inotify/blob/3cee3331033a9d2cb642076de8aefac3bf0f4e3b/lib/rb-inotify/notifier.rb#L234), then `Notifier#run` will loop until `Notifier#stop` is called again.  Furthermore, if `Notifier#run` acquires the `@running` mutex before `Notifier#stop` does (but after `Notifier#stop` sets `@stop = true`), then `Notifier#stop` will get stuck waiting for the mutex while `Notifier#run` infinitely loops.

This commit modifies `Notifier#run` to assume `@stop == false` when it begins, and to reset `@stop = false` only after its loop terminates, thus eliminating the race.
