### PR TITLE
Raise an error when path is specified with :moved_from or :moved_to

### DIFF
--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -195,7 +195,12 @@ module INotify
     # @raise [SystemCallError] if the file or directory can't be watched,
     #   e.g. if the file isn't found, read access is denied,
     #   or the flags don't contain any events
+    # @raise [ArgumentError] if the file is specified with :move_to.
     def watch(path, *flags, &callback)
+      if File.file?(path) and (flags.include?(:moved_to) or flags.include?(:moved_from))
+        raise ArgumentError.new, ":moved_to must not be specified with file #{path}"
+      end
+
       return Watcher.new(self, path, *flags, &callback) unless flags.include?(:recursive)
 
       dir = Dir.new(path)

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -71,6 +71,16 @@ describe INotify::Notifier do
         expect(bar_events.first.name).to eq("test_two.txt")
         expect(bar_events.first.absolute_name).to eq(another_dir.join("test_two.txt").to_s)
       end
+
+      it "file should not specified with :moved_from or :moved_to" do
+        dir.join("one.txt").write("hello world")
+        expect {
+          recording(dir.join("one.txt"), :moved_to)
+        }.to raise_error(ArgumentError)
+        expect {
+          recording(dir.join("one.txt"), :moved_from)
+        }.to raise_error(ArgumentError)
+      end
     end
 
     describe :run do


### PR DESCRIPTION
If same path is specified with :moved_from or :moved_to
additionally, :modify is not fired expectedly.

```
  require "rb-inotify"
  notifier = INotify::Notifier.new
  notifier.watch("test.log", :modify) do |event|
    puts "#{event} is modified"
  end
  notifier.watch("test.log", :moved_from) do |event|
    puts "#{event} is moved_from"
  end
```

Above sample code does not work as expected.
So, raise an error immediately.