### PR TITLE
Implenent missing flags

### DIFF
--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -1,5 +1,3 @@
-require "etc"
-
 module INotify
   module Native
     # A module containing all the inotify flags
@@ -7,12 +5,6 @@ module INotify
     #
     # @private
     module Flags
-      uname = Etc.uname
-      # JRuby always writes release: 'unknown', but :version contains what :release contains on MRI and TruffleRuby.
-      release = RUBY_ENGINE == 'jruby' ? uname[:version] : uname[:release]
-      # give up
-      release = '0.1.0' unless Gem::Version.correct?(release)
-      LINUX_KERNEL_VERSION = Gem::Version.new(release)
       # File was accessed.
       IN_ACCESS = 0x00000001
       # Metadata changed.
@@ -52,27 +44,22 @@ module INotify
 
       ## Special flags.
 
-      if LINUX_KERNEL_VERSION >= Gem::Version.new("2.6.15")
-        # Do not follow a sym link.
-        IN_DONT_FOLLOW = 0x02000000
-        # Only watch the path if it is a directory.
-        IN_ONLYDIR = 0x01000000
-      end
-
-      if LINUX_KERNEL_VERSION >= Gem::Version.new("2.6.36")
-        # Exclude events on unlinked objects.
-        IN_EXCL_UNLINK = 0x04000000
-      end
-      if LINUX_KERNEL_VERSION >= Gem::Version.new("4.18")
-        # Only create watches.
-        IN_MASK_CREATE = 0x10000000
-      end
-
+      # Do not follow a sym link
+      # available since Linux 2.6.15, causes EINVAL othervise
+      IN_DONT_FOLLOW = 0x02000000
+      # Exclude events on unlinked objects.
+      # available since Linux 2.6.36, causes EINVAL othervise
+      IN_EXCL_UNLINK = 0x04000000
       # Add to the mask of an already existing watch.
       IN_MASK_ADD = 0x20000000
       # Only send event once.
       IN_ONESHOT = 0x80000000
-
+      # Only watch the path if it is a directory.
+      # available since Linux 2.6.15, causes EINVAL othervise
+      IN_ONLYDIR = 0x01000000
+      # Only create watches.
+      # available since Linux 4.18, causes EINVAL othervise
+      IN_MASK_CREATE = 0x10000000
 
       ## Events sent by the kernel.
 
@@ -80,10 +67,10 @@ module INotify
       IN_IGNORED = 0x00008000
       # Event occurred against dir.
       IN_ISDIR = 0x40000000
-      # Backing fs was unmounted.
-      IN_UNMOUNT = 0x00002000
       # Event queued overflowed.
       IN_Q_OVERFLOW = 0x00004000
+      # Backing fs was unmounted.
+      IN_UNMOUNT = 0x00002000
 
       EVENT_ONLY_FLAGS = IN_IGNORED | IN_ISDIR | IN_UNMOUNT | IN_Q_OVERFLOW
 

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -7,7 +7,12 @@ module INotify
     #
     # @private
     module Flags
-      LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
+      uname = Etc.uname
+      # JRuby always writes release: 'unknown', but :version contains what :release contains on MRI and TruffleRuby.
+      release = RUBY_PLATFORM == "java" ? uname[:version] : uname[:release]
+      # give up
+      release = '0.1.0' unless Gem::Version.correct?(release)
+      LINUX_KERNEL_VERSION = Gem::Version.new(release)
       # File was accessed.
       IN_ACCESS = 0x00000001
       # Metadata changed.

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -8,6 +8,7 @@ module INotify
     # @private
     module Flags
       LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
+      p LINUX_KERNEL_VERSION
       # File was accessed.
       IN_ACCESS = 0x00000001
       # Metadata changed.

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -9,6 +9,11 @@ module INotify
     module Flags
       LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
       p LINUX_KERNEL_VERSION # trigger workflow
+      begin
+        LINUX_KERNEL_VERSION >= "2.6.15"
+      rescue ArgumentError => e
+        p e.backtrace
+      end
       # File was accessed.
       IN_ACCESS = 0x00000001
       # Metadata changed.

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -1,3 +1,5 @@
+require "etc"
+
 module INotify
   module Native
     # A module containing all the inotify flags
@@ -5,6 +7,7 @@ module INotify
     #
     # @private
     module Flags
+      LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
       # File was accessed.
       IN_ACCESS = 0x00000001
       # Metadata changed.
@@ -44,10 +47,22 @@ module INotify
 
       ## Special flags.
 
-      # Only watch the path if it is a directory.
-      IN_ONLYDIR = 0x01000000
-      # Do not follow a sym link.
-      IN_DONT_FOLLOW = 0x02000000
+      if LINUX_KERNEL_VERSION >= "2.6.15"
+        # Only watch the path if it is a directory.
+        IN_ONLYDIR = 0x01000000
+        # Do not follow a sym link.
+        IN_DONT_FOLLOW = 0x02000000
+      end
+
+      if LINUX_KERNEL_VERSION >= "2.6.36"
+        # Exclude events on unlinked objects.
+        IN_EXCL_UNLINK = 0x04000000
+      end
+      if LINUX_KERNEL_VERSION >= "4.18"
+        # Only create watches.
+        IN_MASK_CREATE = 0x10000000
+      end
+
       # Add to the mask of an already existing watch.
       IN_MASK_ADD = 0x20000000
       # Only send event once.

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -8,14 +8,6 @@ module INotify
     # @private
     module Flags
       LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
-      p LINUX_KERNEL_VERSION # trigger workflow
-      p Gem::Version.instance_method(:<=>)
-      p Gem::Version.instance_method(:>=)
-      begin
-        LINUX_KERNEL_VERSION >= "2.6.15"
-      rescue ArgumentError => e
-        p e.backtrace
-      end
       # File was accessed.
       IN_ACCESS = 0x00000001
       # Metadata changed.
@@ -55,18 +47,18 @@ module INotify
 
       ## Special flags.
 
-      if LINUX_KERNEL_VERSION >= "2.6.15"
+      if LINUX_KERNEL_VERSION >= Gem::Version.new("2.6.15")
         # Only watch the path if it is a directory.
         IN_ONLYDIR = 0x01000000
         # Do not follow a sym link.
         IN_DONT_FOLLOW = 0x02000000
       end
 
-      if LINUX_KERNEL_VERSION >= "2.6.36"
+      if LINUX_KERNEL_VERSION >= Gem::Version.new("2.6.36")
         # Exclude events on unlinked objects.
         IN_EXCL_UNLINK = 0x04000000
       end
-      if LINUX_KERNEL_VERSION >= "4.18"
+      if LINUX_KERNEL_VERSION >= Gem::Version.new("4.18")
         # Only create watches.
         IN_MASK_CREATE = 0x10000000
       end

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -10,7 +10,7 @@ module INotify
       LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
       p LINUX_KERNEL_VERSION # trigger workflow
       p Gem::Version.instance_method(:<=>)
-      p Gem::Version.instance_method(:=>)
+      p Gem::Version.instance_method(:>=)
       begin
         LINUX_KERNEL_VERSION >= "2.6.15"
       rescue ArgumentError => e

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -9,7 +9,7 @@ module INotify
     module Flags
       uname = Etc.uname
       # JRuby always writes release: 'unknown', but :version contains what :release contains on MRI and TruffleRuby.
-      release = RUBY_PLATFORM == "java" ? uname[:version] : uname[:release]
+      release = RUBY_ENGINE == 'jruby' ? uname[:version] : uname[:release]
       # give up
       release = '0.1.0' unless Gem::Version.correct?(release)
       LINUX_KERNEL_VERSION = Gem::Version.new(release)

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -9,6 +9,8 @@ module INotify
     module Flags
       LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
       p LINUX_KERNEL_VERSION # trigger workflow
+      p Gem::Version.instance_method(:<=>)
+      p Gem::Version.instance_method(:=>)
       begin
         LINUX_KERNEL_VERSION >= "2.6.15"
       rescue ArgumentError => e

--- a/lib/rb-inotify/native/flags.rb
+++ b/lib/rb-inotify/native/flags.rb
@@ -8,7 +8,7 @@ module INotify
     # @private
     module Flags
       LINUX_KERNEL_VERSION = Gem::Version.new(Etc.uname[:release])
-      p LINUX_KERNEL_VERSION
+      p LINUX_KERNEL_VERSION # trigger workflow
       # File was accessed.
       IN_ACCESS = 0x00000001
       # Metadata changed.

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -164,16 +164,16 @@ module INotify
     # Instead, they specify options for the watcher.
     #
     # `:onlydir`
-    # : Only watch the path if it's a directory; since Linux 2.6.15
+    # : Only watch the path if it's a directory; since Linux 2.6.15.
     #
     # `:dont_follow`
-    # : Don't follow symlinks; since Linux 2.6.15
+    # : Don't follow symlinks; since Linux 2.6.15.
     #
     # `:excl_unlink`
-    # : Exclude events on unlinked objects; since Linux 2.6.36
+    # : Exclude events on unlinked objects; since Linux 2.6.36.
     #
     # `:mask_create`
-    # : Watch pathname only if it does not already have a watch associated with it, Errno::EEXIST is raised otherwise; since Linux 4.18
+    # : Watch pathname only if it does not already have a watch associated with it, Errno::EEXIST is raised otherwise; since Linux 4.18.
     #
     # `:mask_add`
     # : Add these flags to the pre-existing flags for this path.

--- a/lib/rb-inotify/notifier.rb
+++ b/lib/rb-inotify/notifier.rb
@@ -164,10 +164,16 @@ module INotify
     # Instead, they specify options for the watcher.
     #
     # `:onlydir`
-    # : Only watch the path if it's a directory.
+    # : Only watch the path if it's a directory; since Linux 2.6.15
     #
     # `:dont_follow`
-    # : Don't follow symlinks.
+    # : Don't follow symlinks; since Linux 2.6.15
+    #
+    # `:excl_unlink`
+    # : Exclude events on unlinked objects; since Linux 2.6.36
+    #
+    # `:mask_create`
+    # : Watch pathname only if it does not already have a watch associated with it, Errno::EEXIST is raised otherwise; since Linux 4.18
     #
     # `:mask_add`
     # : Add these flags to the pre-existing flags for this path.

--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
   
   spec.add_dependency "ffi", "~> 1.0"
-  # Isn't added as a dependency because
+  # Isn't not added as a dependency because
   #  - It's a default gem on MRI 3.4.2 and TruffleRuby 24.2.1
   #  - It's not available as a gem on JRuby
   # spec.add_dependency "etc"

--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -20,8 +20,4 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
   
   spec.add_dependency "ffi", "~> 1.0"
-  # Isn't not added as a dependency because
-  #  - It's a default gem on MRI 3.4.2 and TruffleRuby 24.2.1
-  #  - It's not available as a gem on JRuby
-  # spec.add_dependency "etc"
 end

--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
   
   spec.add_dependency "ffi", "~> 1.0"
+  spec.add_dependency "etc"
 end

--- a/rb-inotify.gemspec
+++ b/rb-inotify.gemspec
@@ -20,5 +20,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
   
   spec.add_dependency "ffi", "~> 1.0"
-  spec.add_dependency "etc"
+  # Isn't added as a dependency because
+  #  - It's a default gem on MRI 3.4.2 and TruffleRuby 24.2.1
+  #  - It's not available as a gem on JRuby
+  # spec.add_dependency "etc"
 end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -41,6 +41,19 @@ describe INotify::Notifier do
         expect(events.first.absolute_name).to eq(dir.join("test.txt").to_s)
       end
 
+      it "ensures that new watches do not modify existing ones" do
+        skip "too old kernel" unless defined?(INotify::Native::Flags::IN_MASK_CREATE)
+
+        events = recording(dir, :create, :oneshot, :mask_create)
+        expect do
+          recording(dir, :create, :oneshot, :mask_create)
+        end.to raise_error(Errno::EEXIST)
+        dir.join("test.txt").write("hello world")
+        expect do
+          recording(dir, :create, :oneshot, :mask_create)
+        end.not_to raise_error
+      end
+
       it "gets simultaneous events" do
         events = recording(dir, :create)
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -44,7 +44,7 @@ describe INotify::Notifier do
       it "ensures that new watches do not modify existing ones" do
         skip "too old kernel" unless defined?(INotify::Native::Flags::IN_MASK_CREATE)
 
-        events = recording(dir, :create, :oneshot, :mask_create)
+        recording(dir, :create, :oneshot, :mask_create)
         expect do
           recording(dir, :create, :oneshot, :mask_create)
         end.to raise_error(Errno::EEXIST)

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -54,6 +54,12 @@ describe INotify::Notifier do
         end.not_to raise_error
       end
 
+      it "fails if flags are not supported" do
+        expect do
+          recording(dir, :create, :oneshot, :unknown_flag)
+        end.to raise_error(NameError, 'uninitialized constant INotify::Native::Flags::IN_UNKNOWN_FLAG')
+      end
+
       it "gets simultaneous events" do
         events = recording(dir, :create)
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -42,8 +42,6 @@ describe INotify::Notifier do
       end
 
       it "ensures that new watches do not modify existing ones" do
-        skip "too old kernel" unless defined?(INotify::Native::Flags::IN_MASK_CREATE)
-
         recording(dir, :create, :oneshot, :mask_create)
         expect do
           recording(dir, :create, :oneshot, :mask_create)

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -58,6 +58,9 @@ describe INotify::Notifier do
         expect do
           recording(dir, :create, :oneshot, :unknown_flag)
         end.to raise_error(NameError, 'uninitialized constant INotify::Native::Flags::IN_UNKNOWN_FLAG')
+        expect do
+          recording(dir, :create, :isdir)
+        end.to raise_error(ArgumentError, 'Invalid flag: isdir')
       end
 
       it "gets simultaneous events" do


### PR DESCRIPTION
Implemented `IN_EXCL_UNLINK` and `IN_MASK_CREATE`
guarded `IN_ONLYDIR` and `IN_DONT_FOLLOW`, affects really old kernels only